### PR TITLE
Addressing Compilation Issue (interface level) -- BREAKS GENERALITY & FUNCTIONALITY

### DIFF
--- a/check_iface_tests.py
+++ b/check_iface_tests.py
@@ -1,0 +1,24 @@
+# Think of this as an "interface" that needs to be implemented for whichever
+# unit-testing framework you are choosing for the automated assessment tool.
+#
+# This interface allows a general approach for discovering if the "iface" (interface)
+# level tests ran for the AAT.
+#
+# You must complete the function however you see fit, as make sure it returns a boolean.
+# You may:
+#     - Add additional functions (if needed)
+#
+# You MUST make sure that the final return value in 'did_iface_tests_compile' is representative of the following:
+#     - TRUE -> the unit tests you wrote were able to compile with student code, and ran with student code
+#     - FALSE -> the unit tests you wrote were NOT able to compile with student code, and they did not run
+#
+#     Note: The TRUE and FALSE are not implications of passing all (or any) tests, but solely
+#     verification that the tests were able to run successfully.
+
+
+
+'''
+TODO! Must implement for accuracy regarding compilation issues.
+'''
+def did_iface_tests_compile():
+    return True

--- a/config.json
+++ b/config.json
@@ -5,6 +5,7 @@
   "file_versions": ["base", "logger"],
   "c_version": "99",
   "allow_vla": true,
+  "interface_testing": false,
   "suite": [
      {
       "module":"test_main_menu",

--- a/main.py
+++ b/main.py
@@ -9,6 +9,7 @@ import sys
 import glob
 
 import helpers
+from check_iface_tests import did_iface_tests_compile
 
 from helpers import submission_dir, source_dir, results_dir
 
@@ -250,17 +251,19 @@ if __name__ == '__main__':
 
         results.append(result)
 
-        # Check to see that here was no compilation error with the unit test (UnitTests.c)
-        path_to_search = submission_dir.join('**/testing_results.xml')
-        found = False
+        # Check to see that there was no compilation error with the unit tests (if unit testing was used)
+        unit_tests_present = data['interface_testing']
 
-        for f in glob.glob(path_to_search, recursive=True):
-            found = True
+        if unit_tests_present:
+            unit_tests_ran = did_iface_tests_compile()
 
-        if found:
-            build_json(results)
-        else:
-            build_json_on_compilation_fail(results)
+            if unit_tests_ran:
+                build_json(results)
+            else:
+                build_json_on_compilation_fail(results)
+
+        elif not unit_tests_present:
+            build_json_on_fail(results)
 
     # remove this at the end just in case
     helpers.remove_file("malloc_log.csv")

--- a/main.py
+++ b/main.py
@@ -6,6 +6,7 @@ import shutil
 import subprocess
 import os
 import sys
+import glob
 
 import helpers
 
@@ -76,6 +77,44 @@ def build_json(test_results):
     with open(os.path.join(results_dir, 'results.json'), 'w') as file:
         json.dump(data, file, indent=4, sort_keys=True)
 
+def build_json_on_compilation_fail(test_results):
+    data = {
+        "output": "Project failed to build (failure to build with C unit tests). Make sure to follow the project outline.",
+        "stdout_visibility": "visible",
+        "tests": [],
+
+    }
+
+    submission_score = 0
+    # weights points relative to the default norm of 30
+    SUBMISSION_WEIGHT = 1
+
+    for result in test_results:
+        for i, piece in enumerate(result[0]):
+            print(result[1][i], result[0][i], result[3][i])
+
+            test = {
+                "max_score": (result[1][i] * SUBMISSION_WEIGHT),
+                "name": result[0][i],
+                # "number": result[2][i],
+                "output": result[3][i]
+            }
+
+            if result[2][i] is True:
+                submission_score += (result[1][i] * SUBMISSION_WEIGHT)
+                test["score"] = (result[1][i] * SUBMISSION_WEIGHT)
+            else:
+                test["score"] = 0
+
+            data["tests"].append(test)
+
+    data["tests"].sort(key=lambda x: x["name"])
+
+    with open(os.path.join(results_dir, 'results.json'), 'w') as file:
+        json.dump(data, file, indent=4, sort_keys=True)
+
+    with open(os.path.join(results_dir, 'results.json'), 'w') as file:
+        json.dump(data, file, indent=4, sort_keys=True)
 
 # builds the json file for when the autograder fails
 def build_json_on_fail(error):
@@ -211,7 +250,17 @@ if __name__ == '__main__':
 
         results.append(result)
 
-    build_json(results)
+        # Check to see that here was no compilation error with the unit test (UnitTests.c)
+        path_to_search = submission_dir.join('**/testing_results.xml')
+        found = False
+
+        for f in glob.glob(path_to_search, recursive=True):
+            found = True
+
+        if found:
+            build_json(results)
+        else:
+            build_json_on_compilation_fail(results)
 
     # remove this at the end just in case
     helpers.remove_file("malloc_log.csv")


### PR DESCRIPTION
This change provides a check for a compilation failure at the interface level.

Previously if students' code was not able to be compiled with the unit testing test suite in M3, they would get a 0 for the assignment instead of getting graded on the application-level (python tests).

Disclaimer: This solution only really applies for M3. It assumes that 1) Interface level testing occurs at some point
2) The unit-testing framework used was CUnit

Some other solutions to this problem include:
1. Backward-compatible new main.py which accepts a new optional arg to specify the existence of unit tests

2. Modifications to config.json as well as a new python "interface" file that would need to be overridden by the AAT developer. Could also include the backward compatability to main.py.